### PR TITLE
Update ko-KR.ts (Added Missing Account Deletion Description)

### DIFF
--- a/packages/localizations/src/ko-KR.ts
+++ b/packages/localizations/src/ko-KR.ts
@@ -350,6 +350,12 @@ export const koKR: LocalizationResource = {
         destructiveActionSubtitle: '이 web3 지갑을 계정에서 삭제',
         destructiveAction: '지갑 제거',
       },
+       dangerSection: {
+        title: '위험',
+        deleteAccountButton: '계정 삭제',
+        deleteAccountTitle: '계정 삭제',
+        deleteAccountDescription: '계정과 관련된 모든 데이터와 계정을 삭제합니다',
+      },
     },
     profilePage: {
       title: '프로필 업데이트',


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other: Translation Update

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [x] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
In the English translation(en-US.ts), the description 'Delete your account and all its associated data' was present. However, this was missing in the Korean translation(ko-KR.ts). 

This update ensures that the Korean translation also includes the information about deleting all data associated with the account.

This change is essential to provide a clearer understanding to users about the consequences of deleting their account.

<!-- Fixes # (issue number) -->
